### PR TITLE
Need to update the version of the subcharts as well

### DIFF
--- a/charts/cp-kafka-connect/Chart.yaml
+++ b/charts/cp-kafka-connect/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Kafka Connect on Kubernetes
 name: cp-kafka-connect
-version: 0.1.0
+version: 0.1.1

--- a/charts/cp-kafka-rest/Chart.yaml
+++ b/charts/cp-kafka-rest/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Kafka REST Proxy on Kubernetes
 name: cp-kafka-rest
-version: 0.1.0
+version: 0.1.1

--- a/charts/cp-kafka/Chart.yaml
+++ b/charts/cp-kafka/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Kafka on Kubernetes
 name: cp-kafka
-version: 0.1.0
+version: 0.1.1

--- a/charts/cp-kafka/requirements.yaml
+++ b/charts/cp-kafka/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: cp-zookeeper
-  version: 0.1.0
+  version: 0.1.1
   repository: file://../cp-zookeeper
   condition: cp-zookeeper.enabled

--- a/charts/cp-ksql-server/Chart.yaml
+++ b/charts/cp-ksql-server/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent KSQL Server on Kubernetes
 name: cp-ksql-server
-version: 0.1.0
+version: 0.1.1

--- a/charts/cp-schema-registry/Chart.yaml
+++ b/charts/cp-schema-registry/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Schema Registry on Kubernetes
 name: cp-schema-registry
-version: 0.1.0
+version: 0.1.1

--- a/charts/cp-zookeeper/Chart.yaml
+++ b/charts/cp-zookeeper/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Zookeeper on Kubernetes
 name: cp-zookeeper
-version: 0.1.0
+version: 0.1.1


### PR DESCRIPTION
The ConfigMap "confluent.v1" was empty because the versions for the individual charts in cp-helm-charts also need to be updated. As a consequence the helm release could not be registered.

